### PR TITLE
Move difficulty buttons to the top of puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,32 @@
         </div>
       </header>
       <div class="game-content" x-show="page === ''">
+        <div class="radio-toolbar">
+          <input
+            type="radio"
+            id="difficulty-easy"
+            value="easy"
+            x-model="settings.difficulty"
+            @change="updateSettings"
+          />
+          <label for="difficulty-easy">Easy</label>
+          <input
+            type="radio"
+            id="difficulty-medium"
+            value="medium"
+            x-model="settings.difficulty"
+            @change="updateSettings"
+          />
+          <label for="difficulty-medium">Medium</label>
+          <input
+            type="radio"
+            id="difficulty-hard"
+            value="hard"
+            x-model="settings.difficulty"
+            @change="updateSettings"
+          />
+          <label for="difficulty-hard">Hard</label>
+        </div>
         <div class="guesses-container">
           <div class="guesses">
             <template
@@ -212,39 +238,6 @@
       </div>
       <div class="settings-content" x-show="page === '#settings'" x-cloak>
         <h1>Settings</h1>
-        <div>
-          <h2>Difficulty</h2>
-          <div>
-            <input
-              type="radio"
-              id="difficulty-easy"
-              value="easy"
-              x-model="settings.difficulty"
-              @change="updateSettings"
-            />
-            <label for="difficulty-easy">Easy</label>
-          </div>
-          <div>
-            <input
-              type="radio"
-              id="difficulty-medium"
-              value="medium"
-              x-model="settings.difficulty"
-              @change="updateSettings"
-            />
-            <label for="difficulty-medium">Medium</label>
-          </div>
-          <div>
-            <input
-              type="radio"
-              id="difficulty-hard"
-              value="hard"
-              x-model="settings.difficulty"
-              @change="updateSettings"
-            />
-            <label for="difficulty-hard">Hard</label>
-          </div>
-        </div>
         <div>
           <h2>Letters</h2>
           <div>

--- a/public/main.css
+++ b/public/main.css
@@ -145,6 +145,33 @@ a {
   }
 }
 
+.radio-toolbar {
+  margin: 2px;
+}
+
+.radio-toolbar input[type="radio"] {
+  opacity: 0;
+  position: fixed;
+  width: 0;
+}
+
+.radio-toolbar label {
+  display: inline-block;
+  background-color: #81837b6e;
+  padding: 10px 20px;
+  font-size: 16px;
+  border: 2px solid var(--color-neutral-20);
+  border-radius: 4px;
+}
+
+.radio-toolbar label:hover {
+  cursor: pointer;
+}
+
+.radio-toolbar input[type="radio"]:checked + label {
+  background-color: #08adff;
+}
+
 .guesses-tile {
   display: inline-flex;
   justify-content: center;


### PR DESCRIPTION
Instead of hidden in settings.

Noticed in Amplitude we get a lot of people playing Easy but < 10% playing Medium or Hard.
<img width="546" alt="Screen Shot 2022-02-08 at 9 00 42 PM" src="https://user-images.githubusercontent.com/513961/153125186-2d0d7aab-4167-4656-a385-96d72b4c09be.png">

